### PR TITLE
Add support for common labels

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -36,13 +36,13 @@ Open another terminal and curl the endpoint a few times to see the output.
  $ curl http://localhost:9568/metrics
 # HELP prometheus_metrics_table_size_total A gauge of the key count of a prometheus metrics aggregation table
 # TYPE prometheus_metrics_table_size_total gauge
-prometheus_metrics_table_size_total{name="prometheus_metrics_dist"} 1 1555038768802809000
-prometheus_metrics_table_size_total{name="prometheus_metrics"} 4 1555038768802809000
+prometheus_metrics_table_size_total{name="prometheus_metrics_dist"} 1
+prometheus_metrics_table_size_total{name="prometheus_metrics"} 4
 
 # HELP prometheus_metrics_table_memory_bytes A gauge of the memory size of a prometheus metrics aggregation table
 # TYPE prometheus_metrics_table_memory_bytes gauge
-prometheus_metrics_table_memory_bytes{name="prometheus_metrics_dist"} 1356 1555038768802809000
-prometheus_metrics_table_memory_bytes{name="prometheus_metrics"} 1426 1555038768802809000
+prometheus_metrics_table_memory_bytes{name="prometheus_metrics_dist"} 1356
+prometheus_metrics_table_memory_bytes{name="prometheus_metrics"} 1426
 
 # HELP prometheus_metrics_scrape_duration_seconds A histogram of the request duration for prometheus metrics scrape.
 # TYPE prometheus_metrics_scrape_duration_seconds histogram
@@ -137,5 +137,9 @@ for more information on tag usage.
 is further complicated as a time series is created for each bucket plus one for measurements
 exceeding the limit of the last bucket - `+Inf`.*
 
-It is _highly_ recommended to abide by Prometheus' best practices regarding labels -
+It is recommended, but not required, to abide by Prometheus' best practices regarding labels -
 [Label Best Practices](https://prometheus.io/docs/practices/naming/#labels)
+
+You can add a default list of static labels to all of your aggregations on export
+by passing the `:common_tag_values` option on init. This is useful for tags that
+won't change but you need on all time series, e.g. deployed env, service name, etc.

--- a/lib/telemetry_metrics_prometheus/registry.ex
+++ b/lib/telemetry_metrics_prometheus/registry.ex
@@ -2,6 +2,8 @@ defmodule TelemetryMetricsPrometheus.Registry do
   @moduledoc false
   use GenServer
 
+  @type name :: atom()
+
   require Logger
 
   alias Telemetry.Metrics
@@ -22,6 +24,7 @@ defmodule TelemetryMetricsPrometheus.Registry do
 
     {:ok,
      %{
+       common_tag_values: opts[:common_tag_values],
        config: %{aggregates_table_id: aggregates_table_id, dist_table_id: dist_table_id},
        metrics: []
      }}
@@ -34,14 +37,23 @@ defmodule TelemetryMetricsPrometheus.Registry do
     GenServer.call(name, {:register, metric})
   end
 
-  @spec config(atom()) :: %{aggregates_table_id: atom(), dist_table_id: atom()}
+  @spec common_tag_values(name()) :: TelemetryMetricsPrometheus.common_tag_values()
+  def common_tag_values(name) do
+    GenServer.call(name, :get_common_tag_values)
+  end
+
+  @spec config(name()) :: %{aggregates_table_id: atom(), dist_table_id: atom()}
   def config(name) do
     GenServer.call(name, :get_config)
   end
 
-  @spec metrics(atom()) :: [{TelemetryMetricsPrometheus.metric(), :telemetry.handler_id()}]
+  @spec metrics(name()) :: [{TelemetryMetricsPrometheus.metric(), :telemetry.handler_id()}]
   def metrics(name) do
     GenServer.call(name, :get_metrics)
+  end
+
+  def handle_call(:get_common_tag_values, _from, state) do
+    {:reply, state.common_tag_values, state}
   end
 
   def handle_call(:get_config, _from, state) do

--- a/test/exporter_test.exs
+++ b/test/exporter_test.exs
@@ -8,8 +8,8 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
       expected = """
       # HELP http_request_total The total number of HTTP requests.
       # TYPE http_request_total counter
-      http_request_total{code="200",method="post"} 1027
-      http_request_total{code="400",method="post"} 3\
+      http_request_total{code="200",env="prod",method="post",service="cart"} 1027
+      http_request_total{code="400",env="prod",method="post",service="cart"} 3\
       """
 
       metric =
@@ -23,7 +23,7 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
         {{[:http, :request, :total], %{"method" => "post", "code" => "400"}}, 3}
       ]
 
-      result = Exporter.format(metric, time_series)
+      result = Exporter.format(metric, time_series, env: :prod, service: "cart")
 
       assert result == expected
     end
@@ -44,7 +44,7 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
         {{[:http, :request, :total], %{}}, 1027}
       ]
 
-      result = Exporter.format(metric, time_series)
+      result = Exporter.format(metric, time_series, [])
 
       assert result == expected
     end
@@ -53,8 +53,8 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
       expected = """
       # HELP cache_keys_total The total number of cache keys.
       # TYPE cache_keys_total gauge
-      cache_keys_total{name="users"} 1027
-      cache_keys_total{name="short_urls"} 3\
+      cache_keys_total{env="prod",name="users",service="cart"} 1027
+      cache_keys_total{env="prod",name="short_urls",service="cart"} 3\
       """
 
       metric =
@@ -68,7 +68,7 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
         {{[:cache, :keys, :total], %{"name" => "short_urls"}}, 3}
       ]
 
-      result = Exporter.format(metric, time_series)
+      result = Exporter.format(metric, time_series, env: :prod, service: "cart")
 
       assert result == expected
     end
@@ -89,7 +89,7 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
         {{[:cache, :key, :total], %{}}, 1027}
       ]
 
-      result = Exporter.format(metric, time_series)
+      result = Exporter.format(metric, time_series, [])
 
       assert result == expected
     end
@@ -98,8 +98,8 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
       expected = """
       # HELP cache_key_invalidations_total The total number of cache key invalidations.
       # TYPE cache_key_invalidations_total counter
-      cache_key_invalidations_total{name="users"} 1027
-      cache_key_invalidations_total{name="short_urls"} 3\
+      cache_key_invalidations_total{env="prod",name="users",service="cart"} 1027
+      cache_key_invalidations_total{env="prod",name="short_urls",service="cart"} 3\
       """
 
       metric =
@@ -113,7 +113,7 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
         {{[:cache, :key, :invalidations, :total], %{"name" => "short_urls"}}, 3}
       ]
 
-      result = Exporter.format(metric, time_series)
+      result = Exporter.format(metric, time_series, env: :prod, service: "cart")
 
       assert result == expected
     end
@@ -134,7 +134,7 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
         {{[:cache, :key, :invalidations, :total], %{}}, 1027}
       ]
 
-      result = Exporter.format(metric, time_series)
+      result = Exporter.format(metric, time_series, [])
 
       assert result == expected
     end
@@ -143,14 +143,14 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
       expected = """
       # HELP http_request_duration_seconds A histogram of the request duration.
       # TYPE http_request_duration_seconds histogram
-      http_request_duration_seconds_bucket{method="GET",le="0.05"} 24054
-      http_request_duration_seconds_bucket{method="GET",le="0.1"} 33444
-      http_request_duration_seconds_bucket{method="GET",le="0.2"} 100392
-      http_request_duration_seconds_bucket{method="GET",le="0.5"} 129389
-      http_request_duration_seconds_bucket{method="GET",le="1"} 133988
-      http_request_duration_seconds_bucket{method="GET",le="+Inf"} 144320
-      http_request_duration_seconds_sum{method="GET"} 53423
-      http_request_duration_seconds_count{method="GET"} 144320\
+      http_request_duration_seconds_bucket{env="prod",method="GET",service="cart",le="0.05"} 24054
+      http_request_duration_seconds_bucket{env="prod",method="GET",service="cart",le="0.1"} 33444
+      http_request_duration_seconds_bucket{env="prod",method="GET",service="cart",le="0.2"} 100392
+      http_request_duration_seconds_bucket{env="prod",method="GET",service="cart",le="0.5"} 129389
+      http_request_duration_seconds_bucket{env="prod",method="GET",service="cart",le="1"} 133988
+      http_request_duration_seconds_bucket{env="prod",method="GET",service="cart",le="+Inf"} 144320
+      http_request_duration_seconds_sum{env="prod",method="GET",service="cart"} 53423
+      http_request_duration_seconds_count{env="prod",method="GET",service="cart"} 144320\
       """
 
       metric =
@@ -173,7 +173,9 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
       result =
         Exporter.format(
           metric,
-          [{{metric.name, %{"method" => "GET"}}, {buckets, 144_320, 53423}}]
+          [{{metric.name, %{"method" => "GET"}}, {buckets, 144_320, 53423}}],
+          env: :prod,
+          service: "cart"
         )
 
       assert result == expected
@@ -209,7 +211,7 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
         {"+Inf", 144_320}
       ]
 
-      result = Exporter.format(metric, [{{metric.name, %{}}, {buckets, 144_320, 53423}}])
+      result = Exporter.format(metric, [{{metric.name, %{}}, {buckets, 144_320, 53423}}], [])
 
       assert result == expected
     end


### PR DESCRIPTION
Allows for adding k/v pairs of tags to be added to all exported time series. This allows users to specify static labels such as env or service names, etc.