### PR TITLE
Revert common tags

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -109,22 +109,23 @@ conventions. By default, the name provided when creating your definition uses pa
 of the provided name to determine what event to listen to and which event measurement
 to use.
 
-For example, `http.request.duration` results in listening for  `[:http, :request]`
+For example, `"http.request.duration"` results in listening for  `[:http, :request]`
 events and use `:duration` from the event measurements. Prometheus would recommend
-a name of `http_request_duration_seconds` as a good name.
+a name of `"http_request_duration_seconds"` as a good name.
 
 It is therefore recommended to use the name in your definition to reflect the name
-you wish to see reported, e.g. `http.request.duration.seconds` or `[:http, :request, :duration, :seconds]` and use the `:event_name` override and `:measurement` options in your definition.
+you wish to see reported, e.g. `"http.request.duration.seconds"` or `[:http, :request, :duration, :seconds]` and use the `:event_name` override and `:measurement` options in your definition.
 
 Example:
-
+```
 Metrics.distribution(
-"http.request.duration.seconds",
-buckets: [0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1],
-event_name: [:http, :request, :complete],
-measurement: :duration,
-unit: {:native, :second}
+  "http.request.duration.seconds",
+  buckets: [0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1],
+  event_name: [:http, :request, :complete],
+  measurement: :duration,
+  unit: {:native, :second}
 )
+```
 
 The exporter sanitizes names to Prometheus' requirements [Naming](https://prometheus.io/docs/instrumenting/writing_exporters/#naming) and joins the event name parts with an underscore.
 
@@ -140,6 +141,18 @@ exceeding the limit of the last bucket - `+Inf`.*
 It is recommended, but not required, to abide by Prometheus' best practices regarding labels -
 [Label Best Practices](https://prometheus.io/docs/practices/naming/#labels)
 
-You can add a default list of static labels to all of your aggregations on export
-by passing the `:common_tag_values` option on init. This is useful for tags that
-won't change but you need on all time series, e.g. deployed env, service name, etc.
+### Included Metrics
+
+Several metrics are exported by default to monitor scrape metrics and internal
+`:ets` table usage.
+
+The metric names are:
+
+  * `"prometheus_metrics_scrape_duration_seconds"`
+  * `"prometheus_metrics_aggregation_duration_seconds"`
+  * `"prometheus_metrics_table_memory_bytes"`
+  * `"prometheus_metrics_table_size_total"`
+
+Please report any abnormally large table usage. Histogram measurements are currently only 
+aggregated at the time of the scrape. We can take a different approach if this proves to be 
+an issue.

--- a/lib/telemetry_metrics_prometheus/registry.ex
+++ b/lib/telemetry_metrics_prometheus/registry.ex
@@ -24,7 +24,6 @@ defmodule TelemetryMetricsPrometheus.Registry do
 
     {:ok,
      %{
-       common_tag_values: opts[:common_tag_values],
        config: %{aggregates_table_id: aggregates_table_id, dist_table_id: dist_table_id},
        metrics: []
      }}
@@ -37,11 +36,6 @@ defmodule TelemetryMetricsPrometheus.Registry do
     GenServer.call(name, {:register, metric})
   end
 
-  @spec common_tag_values(name()) :: TelemetryMetricsPrometheus.common_tag_values()
-  def common_tag_values(name) do
-    GenServer.call(name, :get_common_tag_values)
-  end
-
   @spec config(name()) :: %{aggregates_table_id: atom(), dist_table_id: atom()}
   def config(name) do
     GenServer.call(name, :get_config)
@@ -50,10 +44,6 @@ defmodule TelemetryMetricsPrometheus.Registry do
   @spec metrics(name()) :: [{TelemetryMetricsPrometheus.metric(), :telemetry.handler_id()}]
   def metrics(name) do
     GenServer.call(name, :get_metrics)
-  end
-
-  def handle_call(:get_common_tag_values, _from, state) do
-    {:reply, state.common_tag_values, state}
   end
 
   def handle_call(:get_config, _from, state) do

--- a/test/exporter_test.exs
+++ b/test/exporter_test.exs
@@ -8,8 +8,8 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
       expected = """
       # HELP http_request_total The total number of HTTP requests.
       # TYPE http_request_total counter
-      http_request_total{code="200",env="prod",method="post",service="cart"} 1027
-      http_request_total{code="400",env="prod",method="post",service="cart"} 3\
+      http_request_total{code="200",method="post"} 1027
+      http_request_total{code="400",method="post"} 3\
       """
 
       metric =
@@ -23,7 +23,7 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
         {{[:http, :request, :total], %{"method" => "post", "code" => "400"}}, 3}
       ]
 
-      result = Exporter.format(metric, time_series, env: :prod, service: "cart")
+      result = Exporter.format(metric, time_series)
 
       assert result == expected
     end
@@ -44,7 +44,7 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
         {{[:http, :request, :total], %{}}, 1027}
       ]
 
-      result = Exporter.format(metric, time_series, [])
+      result = Exporter.format(metric, time_series)
 
       assert result == expected
     end
@@ -53,8 +53,8 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
       expected = """
       # HELP cache_keys_total The total number of cache keys.
       # TYPE cache_keys_total gauge
-      cache_keys_total{env="prod",name="users",service="cart"} 1027
-      cache_keys_total{env="prod",name="short_urls",service="cart"} 3\
+      cache_keys_total{name="users"} 1027
+      cache_keys_total{name="short_urls"} 3\
       """
 
       metric =
@@ -68,7 +68,7 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
         {{[:cache, :keys, :total], %{"name" => "short_urls"}}, 3}
       ]
 
-      result = Exporter.format(metric, time_series, env: :prod, service: "cart")
+      result = Exporter.format(metric, time_series)
 
       assert result == expected
     end
@@ -89,7 +89,7 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
         {{[:cache, :key, :total], %{}}, 1027}
       ]
 
-      result = Exporter.format(metric, time_series, [])
+      result = Exporter.format(metric, time_series)
 
       assert result == expected
     end
@@ -98,8 +98,8 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
       expected = """
       # HELP cache_key_invalidations_total The total number of cache key invalidations.
       # TYPE cache_key_invalidations_total counter
-      cache_key_invalidations_total{env="prod",name="users",service="cart"} 1027
-      cache_key_invalidations_total{env="prod",name="short_urls",service="cart"} 3\
+      cache_key_invalidations_total{name="users"} 1027
+      cache_key_invalidations_total{name="short_urls"} 3\
       """
 
       metric =
@@ -113,7 +113,7 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
         {{[:cache, :key, :invalidations, :total], %{"name" => "short_urls"}}, 3}
       ]
 
-      result = Exporter.format(metric, time_series, env: :prod, service: "cart")
+      result = Exporter.format(metric, time_series)
 
       assert result == expected
     end
@@ -134,7 +134,7 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
         {{[:cache, :key, :invalidations, :total], %{}}, 1027}
       ]
 
-      result = Exporter.format(metric, time_series, [])
+      result = Exporter.format(metric, time_series)
 
       assert result == expected
     end
@@ -143,14 +143,14 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
       expected = """
       # HELP http_request_duration_seconds A histogram of the request duration.
       # TYPE http_request_duration_seconds histogram
-      http_request_duration_seconds_bucket{env="prod",method="GET",service="cart",le="0.05"} 24054
-      http_request_duration_seconds_bucket{env="prod",method="GET",service="cart",le="0.1"} 33444
-      http_request_duration_seconds_bucket{env="prod",method="GET",service="cart",le="0.2"} 100392
-      http_request_duration_seconds_bucket{env="prod",method="GET",service="cart",le="0.5"} 129389
-      http_request_duration_seconds_bucket{env="prod",method="GET",service="cart",le="1"} 133988
-      http_request_duration_seconds_bucket{env="prod",method="GET",service="cart",le="+Inf"} 144320
-      http_request_duration_seconds_sum{env="prod",method="GET",service="cart"} 53423
-      http_request_duration_seconds_count{env="prod",method="GET",service="cart"} 144320\
+      http_request_duration_seconds_bucket{method="GET",le="0.05"} 24054
+      http_request_duration_seconds_bucket{method="GET",le="0.1"} 33444
+      http_request_duration_seconds_bucket{method="GET",le="0.2"} 100392
+      http_request_duration_seconds_bucket{method="GET",le="0.5"} 129389
+      http_request_duration_seconds_bucket{method="GET",le="1"} 133988
+      http_request_duration_seconds_bucket{method="GET",le="+Inf"} 144320
+      http_request_duration_seconds_sum{method="GET"} 53423
+      http_request_duration_seconds_count{method="GET"} 144320\
       """
 
       metric =
@@ -173,9 +173,7 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
       result =
         Exporter.format(
           metric,
-          [{{metric.name, %{"method" => "GET"}}, {buckets, 144_320, 53423}}],
-          env: :prod,
-          service: "cart"
+          [{{metric.name, %{"method" => "GET"}}, {buckets, 144_320, 53423}}]
         )
 
       assert result == expected
@@ -211,7 +209,7 @@ defmodule TelemetryMetricsPrometheus.ExporterTest do
         {"+Inf", 144_320}
       ]
 
-      result = Exporter.format(metric, [{{metric.name, %{}}, {buckets, 144_320, 53423}}], [])
+      result = Exporter.format(metric, [{{metric.name, %{}}, {buckets, 144_320, 53423}}])
 
       assert result == expected
     end

--- a/test/registry_test.exs
+++ b/test/registry_test.exs
@@ -12,7 +12,7 @@ defmodule TelemetryMetricsPrometheus.RegistryTest do
       Metrics.sum("cache.invalidations.total")
     ]
 
-    opts = [name: :test, common_tag_values: []]
+    opts = [name: :test]
 
     %{definitions: definitions, opts: opts}
   end
@@ -50,15 +50,6 @@ defmodule TelemetryMetricsPrometheus.RegistryTest do
 
     assert Map.has_key?(config, :aggregates_table_id)
     assert Map.has_key?(config, :dist_table_id)
-
-    cleanup(pid)
-  end
-
-  test "retrieves common tag values", %{opts: opts} do
-    {:ok, pid} =
-      Registry.start_link(Keyword.replace!(opts, :common_tag_values, service: "abc", env: "prod"))
-
-    assert Registry.common_tag_values(:test) == [service: "abc", env: "prod"]
 
     cleanup(pid)
   end


### PR DESCRIPTION
This functionality is standard for Prometheus server configs and it turns out we can handle this in our Datadog config, so this no longer seems useful.