### PR TITLE
Set content type header

### DIFF
--- a/lib/telemetry_metrics_prometheus/router.ex
+++ b/lib/telemetry_metrics_prometheus/router.ex
@@ -14,6 +14,7 @@ defmodule TelemetryMetricsPrometheus.Router do
 
     conn
     |> Conn.put_private(:prometheus_metrics_name, name)
+    |> Conn.put_resp_content_type("text/plain")
     |> Conn.send_resp(200, metrics)
   end
 

--- a/test/router_test.exs
+++ b/test/router_test.exs
@@ -17,4 +17,19 @@ defmodule TelemetryMetricsPrometheus.RouterTest do
     assert conn.state == :sent
     assert conn.status == 404
   end
+
+  test "returns a scrape" do
+    # Create a test connection
+    conn = conn(:get, "/metrics")
+
+    TelemetryMetricsPrometheus.init([], name: :test)
+
+    # Invoke the plug
+    conn = Router.call(conn, Router.init(name: :test))
+
+    # Assert the response and status
+    assert conn.state == :sent
+    assert conn.status == 200
+    assert get_resp_header(conn, "content-type") |> hd() =~ "text/plain"
+  end
 end

--- a/test/router_test.exs
+++ b/test/router_test.exs
@@ -22,7 +22,7 @@ defmodule TelemetryMetricsPrometheus.RouterTest do
     # Create a test connection
     conn = conn(:get, "/metrics")
 
-    TelemetryMetricsPrometheus.init([], name: :test)
+    TelemetryMetricsPrometheus.init([], [name: :test, port: 9999])
 
     # Invoke the plug
     conn = Router.call(conn, Router.init(name: :test))
@@ -31,5 +31,7 @@ defmodule TelemetryMetricsPrometheus.RouterTest do
     assert conn.state == :sent
     assert conn.status == 200
     assert get_resp_header(conn, "content-type") |> hd() =~ "text/plain"
+
+    TelemetryMetricsPrometheus.stop(:test)
   end
 end


### PR DESCRIPTION
DataDog agents have an internal check that requires the content-type header to be set. This PR adds the header.