### PR TITLE
fix: Updates telemetry_poller to the Erlang API

### DIFF
--- a/lib/telemetry_metrics_prometheus/registry.ex
+++ b/lib/telemetry_metrics_prometheus/registry.ex
@@ -110,7 +110,7 @@ defmodule TelemetryMetricsPrometheus.Registry do
 
     DynamicSupervisor.start_child(
       TelemetryMetricsPrometheus.DynamicSupervisor,
-      {Telemetry.Poller, [measurements: measurement_specs]}
+      {:telemetry_poller, [measurements: measurement_specs]}
     )
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule TelemetryMetricsPrometheus.MixProject do
       {:plug_cowboy, "~> 2.0"},
       {:telemetry, "~> 0.4"},
       {:telemetry_metrics, "~> 0.2"},
-      {:telemetry_poller, "~> 0.3"}
+      {:telemetry_poller, "~> 0.4"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -24,6 +24,6 @@
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], []},
   "telemetry_metrics": {:hex, :telemetry_metrics, "0.2.1", "00d0bfb07dadab8fd6def8a09e93a545759bec36741947a853cb0c4fed1ed8e8", [:mix], [{:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
-  "telemetry_poller": {:hex, :telemetry_poller, "0.3.0", "e67c0a0bcb9d457985e7b8715abe7e98b7c055532b069bcac9a112ce2367c409", [:mix], [{:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
+  "telemetry_poller": {:hex, :telemetry_poller, "0.4.0", "da64dea54b77604023e8d15dc61a5df8968f4c9e013eba561bfb2bc614b15432", [:rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
Currently, Telemetry Metrics Prometheus is incompatible with version 0.4.0 of telemetry_poller.

This PR addresses that issue.