### PR TITLE
Give monitor poller a name

### DIFF
--- a/lib/telemetry_metrics_prometheus.ex
+++ b/lib/telemetry_metrics_prometheus.ex
@@ -153,7 +153,7 @@ defmodule TelemetryMetricsPrometheus do
          config <- Registry.config(opts[:name]) do
       if opts[:monitor_reporter] do
         {:ok, _poller_id} =
-          Registry.monitor_tables([config.aggregates_table_id, config.dist_table_id])
+          Registry.monitor_tables([config.aggregates_table_id, config.dist_table_id], opts[:name])
       end
 
       :ok

--- a/lib/telemetry_metrics_prometheus/registry.ex
+++ b/lib/telemetry_metrics_prometheus/registry.ex
@@ -155,14 +155,15 @@ defmodule TelemetryMetricsPrometheus.Registry do
     :ets.new(name, [:named_table, :public, type, {:write_concurrency, true}])
   end
 
-  @spec monitor_tables([atom()]) :: DynamicSupervisor.on_start_child()
-  def monitor_tables(tables) do
+  @spec monitor_tables([atom()], atom()) :: DynamicSupervisor.on_start_child()
+  def monitor_tables(tables, name) do
     measurement_specs =
       Enum.map(tables, &{TelemetryMetricsPrometheus.Telemetry, :dispatch_table_stats, [&1]})
 
     DynamicSupervisor.start_child(
       TelemetryMetricsPrometheus.DynamicSupervisor,
-      {:telemetry_poller, [measurements: measurement_specs]}
+      {:telemetry_poller,
+       [measurements: measurement_specs, name: String.to_atom("#{name}_poller")]}
     )
   end
 end


### PR DESCRIPTION
Pollers must be given a name going forward. This can already create a bug where an `already started` exit can be thrown.

This PR gives the poller a unique name.