### PR TITLE
Fixes issue with missing registry name in router

### DIFF
--- a/lib/telemetry_metrics_prometheus/supervisor.ex
+++ b/lib/telemetry_metrics_prometheus/supervisor.ex
@@ -14,7 +14,7 @@ defmodule TelemetryMetricsPrometheus.Supervisor do
       {TelemetryMetricsPrometheus.Core, args},
       {Plug.Cowboy,
        scheme: Keyword.get(args, :protocol),
-       plug: Router,
+       plug: {Router, [name: Keyword.get(args, :name)]},
        options: [port: Keyword.get(args, :port)]}
     ]
 


### PR DESCRIPTION
Just updated from `0.1.2` and noticed that the router crashes if someone requests the metrics.
The following error was logged:

```
[error] #PID<0.1010.0> running TelemetryMetricsPrometheus.Router (connection #PID<0.1008.0>, stream id 1) terminated
Server: localhost:9568 (http)
Request: GET /metrics
** (exit) exited in: GenServer.call(nil, :get_config, 5000)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
```

On further investigation I noticed that the name of the registry process is not passed into the router.