### PR TITLE
Adds support for HTTPS via plug_cowboy_opts

### DIFF
--- a/lib/telemetry_metrics_prometheus/supervisor.ex
+++ b/lib/telemetry_metrics_prometheus/supervisor.ex
@@ -15,7 +15,7 @@ defmodule TelemetryMetricsPrometheus.Supervisor do
       {Plug.Cowboy,
        scheme: Keyword.get(args, :protocol),
        plug: {Router, [name: Keyword.get(args, :name)]},
-       options: [port: Keyword.get(args, :port)]}
+       options: Keyword.get(args, :options)}
     ]
 
     Supervisor.init(children, strategy: :rest_for_one)

--- a/test/telemetry_metrics_prometheus_test.exs
+++ b/test/telemetry_metrics_prometheus_test.exs
@@ -7,16 +7,51 @@ defmodule TelemetryMetricsPrometheusTest do
   test "has a child spec" do
     child_spec = TelemetryMetricsPrometheus.child_spec(metrics: [])
 
+    ssl_child_spec =
+      TelemetryMetricsPrometheus.child_spec(
+        metrics: [],
+        port: 9443,
+        protocol: :https,
+        plug_cowboy_opts: [
+          password: "SECRET",
+          otp_app: :my_app,
+          keyfile: "priv/ssl/key.pem",
+          certfile: "priv/ssl/cert.pem",
+          dhfile: "priv/ssl/dhparam.pem"
+        ]
+      )
+
     assert child_spec == %{
              id: :prometheus_metrics,
              start:
                {TelemetryMetricsPrometheus.Supervisor, :start_link,
                 [
                   [
-                    port: 9568,
                     protocol: :http,
                     name: :prometheus_metrics,
+                    options: [port: 9568],
                     metrics: []
+                  ]
+                ]}
+           }
+
+    assert ssl_child_spec == %{
+             id: :prometheus_metrics,
+             start:
+               {TelemetryMetricsPrometheus.Supervisor, :start_link,
+                [
+                  [
+                    name: :prometheus_metrics,
+                    options: [
+                      port: 9443,
+                      password: "SECRET",
+                      otp_app: :my_app,
+                      keyfile: "priv/ssl/key.pem",
+                      certfile: "priv/ssl/cert.pem",
+                      dhfile: "priv/ssl/dhparam.pem"
+                    ],
+                    metrics: [],
+                    protocol: :https
                   ]
                 ]}
            }


### PR DESCRIPTION
I opted to leave the `:port` option as a root option and override the value in `:plug_cowboy_opts` if it is passed to maintain backward compatibility.

Resolves #16 