### PR TITLE
Fix support for running multiple instances

### DIFF
--- a/lib/telemetry_metrics_prometheus/supervisor.ex
+++ b/lib/telemetry_metrics_prometheus/supervisor.ex
@@ -5,17 +5,18 @@ defmodule TelemetryMetricsPrometheus.Supervisor do
   alias TelemetryMetricsPrometheus.Router
 
   def start_link(init_args) do
-    Supervisor.start_link(__MODULE__, init_args, name: __MODULE__)
+    Supervisor.start_link(__MODULE__, init_args, name: :"#{init_args[:name]}_sup")
   end
 
   @impl true
   def init(args) do
     children = [
       {TelemetryMetricsPrometheus.Core, args},
-      {Plug.Cowboy,
-       scheme: Keyword.get(args, :protocol),
-       plug: {Router, [name: Keyword.get(args, :name)]},
-       options: Keyword.get(args, :options)}
+      Plug.Cowboy.child_spec(
+        scheme: Keyword.get(args, :protocol),
+        plug: {Router, [name: Keyword.get(args, :name)]},
+        options: Keyword.get(args, :options)
+      )
     ]
 
     Supervisor.init(children, strategy: :rest_for_one)

--- a/test/telemetry_metrics_prometheus_test.exs
+++ b/test/telemetry_metrics_prometheus_test.exs
@@ -125,6 +125,23 @@ defmodule TelemetryMetricsPrometheusTest do
     assert metrics_scrape =~ "http_request_total"
   end
 
+  test "supports running multiple instances" do
+    _instance_1 =
+      start_supervised!(
+        TelemetryMetricsPrometheus.child_spec(name: :prom_server_1, metrics: [], port: 9999)
+      )
+
+    _instance_2 =
+      start_supervised!(
+        TelemetryMetricsPrometheus.child_spec(
+          name: :prom_server_2,
+          metrics: [],
+          port: 9987,
+          plug_cowboy_opts: [ref: make_ref()]
+        )
+      )
+  end
+
   test "initializes properly using start_link/1" do
     metrics = [
       Metrics.counter("http.request.total",


### PR DESCRIPTION
Supervisors need a unique name to launch multiple instances.