### PR TITLE
Extract plug

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
+  import_deps: [:plug],
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/lib/telemetry_metrics_prometheus/plug.ex
+++ b/lib/telemetry_metrics_prometheus/plug.ex
@@ -1,0 +1,26 @@
+defmodule TelemetryMetricsPrometheus.Plug do
+  @moduledoc """
+  Plug to export Prometheus metrics.
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn
+
+  @impl Plug
+  def init(opts) do
+    opts |> Keyword.put_new(:name, :prometheus_metrics)
+  end
+
+  @impl Plug
+  def call(conn, opts) do
+    name = Keyword.fetch!(opts, :name)
+
+    metrics = TelemetryMetricsPrometheus.Core.scrape(name)
+
+    conn
+    |> put_private(:prometheus_metrics_name, name)
+    |> put_resp_content_type("text/plain")
+    |> send_resp(200, metrics)
+  end
+end

--- a/lib/telemetry_metrics_prometheus/router.ex
+++ b/lib/telemetry_metrics_prometheus/router.ex
@@ -2,23 +2,16 @@ defmodule TelemetryMetricsPrometheus.Router do
   @moduledoc false
 
   use Plug.Router
-  alias Plug.Conn
 
-  plug(:match)
-  plug(Plug.Telemetry, event_prefix: [:prometheus_metrics, :plug])
-  plug(:dispatch, builder_opts())
+  plug :match
+  plug Plug.Telemetry, event_prefix: [:prometheus_metrics, :plug]
+  plug :dispatch, builder_opts()
 
   get "/metrics" do
-    name = opts[:name]
-    metrics = TelemetryMetricsPrometheus.Core.scrape(name)
-
-    conn
-    |> Conn.put_private(:prometheus_metrics_name, name)
-    |> Conn.put_resp_content_type("text/plain")
-    |> Conn.send_resp(200, metrics)
+    TelemetryMetricsPrometheus.Plug.call(conn, opts)
   end
 
   match _ do
-    Conn.send_resp(conn, 404, "Not Found")
+    send_resp(conn, 404, "Not Found")
   end
 end


### PR DESCRIPTION
Instead of running separate cowboy process, I'd like to plug prometheus exporter plug directly to existing endpoint (e.g. to keep everything in one port...)

I could do that with this in Phoenix router.

```elixir
  get "/metrics", TelemetryMetricsPrometheus.Router, [name: :prometheus_metrics]
```

However, I need to call `example.com/metrics/metrics` - since the router has `metrics` path init.

This PR is to extract minimal plug (e.g. not covering other routes, etc.), so that it can be added freely.

Also it adds `@moduledoc` to make it public.