### PR TITLE
fix: Cascade naming down to Plug Cowboy adapter

### DIFF
--- a/lib/telemetry_metrics_prometheus.ex
+++ b/lib/telemetry_metrics_prometheus.ex
@@ -83,7 +83,7 @@ defmodule TelemetryMetricsPrometheus do
     opts = ensure_options(options)
 
     id =
-      case Keyword.get(opts, :name, :prometheus_metrics) do
+      case Keyword.get(opts, :name) do
         name when is_atom(name) -> name
         {:global, name} -> name
         {:via, _, name} -> name
@@ -116,14 +116,15 @@ defmodule TelemetryMetricsPrometheus do
   end
 
   defp ensure_options(options) do
-    {port, opts} =
+    {port, updated_opts} =
       Keyword.merge(default_options(), options)
       |> Keyword.pop(:port)
 
-    Keyword.delete(opts, :plug_cowboy_opts)
+    Keyword.delete(updated_opts, :plug_cowboy_opts)
     |> Keyword.update!(:options, fn opts ->
       Keyword.merge(opts, Keyword.get(options, :plug_cowboy_opts, []))
       |> Keyword.put(:port, port)
+      |> Keyword.put_new(:ref, Keyword.get(updated_opts, :name))
     end)
   end
 

--- a/lib/telemetry_metrics_prometheus/supervisor.ex
+++ b/lib/telemetry_metrics_prometheus/supervisor.ex
@@ -16,11 +16,12 @@ defmodule TelemetryMetricsPrometheus.Supervisor do
         scheme: Keyword.get(args, :protocol),
         plug: {Router, [name: Keyword.get(args, :name)]},
         options:
-          case Keyword.fetch(:name) do
+          case Keyword.fetch(args, :name) do
             {:ok, name} ->
               args
               |> Keyword.get(:options)
               |> Keyword.put_new(:ref, name)
+
             :error ->
               Keyword.get(args, :options)
           end

--- a/lib/telemetry_metrics_prometheus/supervisor.ex
+++ b/lib/telemetry_metrics_prometheus/supervisor.ex
@@ -15,7 +15,15 @@ defmodule TelemetryMetricsPrometheus.Supervisor do
       Plug.Cowboy.child_spec(
         scheme: Keyword.get(args, :protocol),
         plug: {Router, [name: Keyword.get(args, :name)]},
-        options: Keyword.get(args, :options)
+        options:
+          case Keyword.fetch(:name) do
+            {:ok, name} ->
+              args
+              |> Keyword.get(:options)
+              |> Keyword.put_new(:ref, name)
+            :error ->
+              Keyword.get(args, :options)
+          end
       )
     ]
 

--- a/lib/telemetry_metrics_prometheus/supervisor.ex
+++ b/lib/telemetry_metrics_prometheus/supervisor.ex
@@ -15,16 +15,7 @@ defmodule TelemetryMetricsPrometheus.Supervisor do
       Plug.Cowboy.child_spec(
         scheme: Keyword.get(args, :protocol),
         plug: {Router, [name: Keyword.get(args, :name)]},
-        options:
-          case Keyword.fetch(args, :name) do
-            {:ok, name} ->
-              args
-              |> Keyword.get(:options)
-              |> Keyword.put_new(:ref, name)
-
-            :error ->
-              Keyword.get(args, :options)
-          end
+        options: Keyword.get(args, :options)
       )
     ]
 

--- a/test/telemetry_metrics_prometheus_test.exs
+++ b/test/telemetry_metrics_prometheus_test.exs
@@ -29,7 +29,7 @@ defmodule TelemetryMetricsPrometheusTest do
                   [
                     protocol: :http,
                     name: :prometheus_metrics,
-                    options: [port: 9568],
+                    options: [{:ref, :prometheus_metrics}, port: 9568],
                     metrics: []
                   ]
                 ]}
@@ -43,6 +43,7 @@ defmodule TelemetryMetricsPrometheusTest do
                   [
                     name: :prometheus_metrics,
                     options: [
+                      ref: :prometheus_metrics,
                       port: 9443,
                       password: "SECRET",
                       otp_app: :my_app,


### PR DESCRIPTION
There is an issue when one creates 2 instances of the Supervisor in an application.

This change solves that problem by passing down the name of the Supervisor as the reference to the Cowboy Plug adapter.