### PR TITLE
Pre-scrape handler

### DIFF
--- a/lib/telemetry_metrics_prometheus.ex
+++ b/lib/telemetry_metrics_prometheus.ex
@@ -106,6 +106,7 @@ defmodule TelemetryMetricsPrometheus do
   * `:port` - port number for the reporter instance's server. Defaults to `9568`
   * `:protocol` - http protocol scheme to use. Defaults to `:http`
   * `:plug_cowboy_opts` - additional `plug_cowboy` options, such as ssl settings. See [Plug.Cowboy](https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html#module-options) for more information. Defaults to `[]`. Setting the `:port` option here will be overriden by the root `:port` option.
+  * `:pre_scrape` - an optional 0 arity function that will be called each time the metrics endpoint is called, before the metrics are aggregated
 
   All other options are forwarded to `TelemetryMetricsPrometheus.Core`.
   """

--- a/lib/telemetry_metrics_prometheus.ex
+++ b/lib/telemetry_metrics_prometheus.ex
@@ -106,7 +106,7 @@ defmodule TelemetryMetricsPrometheus do
   * `:port` - port number for the reporter instance's server. Defaults to `9568`
   * `:protocol` - http protocol scheme to use. Defaults to `:http`
   * `:plug_cowboy_opts` - additional `plug_cowboy` options, such as ssl settings. See [Plug.Cowboy](https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html#module-options) for more information. Defaults to `[]`. Setting the `:port` option here will be overriden by the root `:port` option.
-  * `:pre_scrape` - an optional 0 arity function that will be called each time the metrics endpoint is called, before the metrics are aggregated
+  * `:pre_scrape` - an MFA tuple defining a function that will be called each time the metrics endpoint is called, before the metrics are aggregated
 
   All other options are forwarded to `TelemetryMetricsPrometheus.Core`.
   """

--- a/lib/telemetry_metrics_prometheus.ex
+++ b/lib/telemetry_metrics_prometheus.ex
@@ -61,6 +61,7 @@ defmodule TelemetryMetricsPrometheus do
           | {:metrics, TelemetryMetricsPrometheus.Core.metrics()}
           | {:protocol, :http | :https}
           | {:plug_cowboy_opts, Keyword.t()}
+          | {:pre_scrape_handler, mfa()}
 
   @type options :: [option]
 
@@ -106,7 +107,7 @@ defmodule TelemetryMetricsPrometheus do
   * `:port` - port number for the reporter instance's server. Defaults to `9568`
   * `:protocol` - http protocol scheme to use. Defaults to `:http`
   * `:plug_cowboy_opts` - additional `plug_cowboy` options, such as ssl settings. See [Plug.Cowboy](https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html#module-options) for more information. Defaults to `[]`. Setting the `:port` option here will be overriden by the root `:port` option.
-  * `:pre_scrape` - an MFA tuple defining a function that will be called each time the metrics endpoint is called, before the metrics are aggregated
+  * `:pre_scrape_handler` - an MFA tuple defining a function that will be called each time the metrics endpoint is called, before the metrics are aggregated
 
   All other options are forwarded to `TelemetryMetricsPrometheus.Core`.
   """
@@ -130,6 +131,15 @@ defmodule TelemetryMetricsPrometheus do
 
   @spec default_options() :: options()
   defp default_options() do
-    [port: 9568, protocol: :http, name: :prometheus_metrics, options: []]
+    [
+      port: 9568,
+      protocol: :http,
+      name: :prometheus_metrics,
+      options: [],
+      pre_scrape_handler: {__MODULE__, :default_pre_scrape_handler, []}
+    ]
   end
+
+  @spec default_pre_scrape_handler() :: :ok
+  def default_pre_scrape_handler, do: :ok
 end

--- a/lib/telemetry_metrics_prometheus/router.ex
+++ b/lib/telemetry_metrics_prometheus/router.ex
@@ -10,8 +10,11 @@ defmodule TelemetryMetricsPrometheus.Router do
 
   get "/metrics" do
     name = opts[:name]
-    pre_scrape = opts[:pre_scrape]
-    unless is_nil(pre_scrape), do: pre_scrape.()
+
+    {pre_scrape_module, pre_scrape_function, pre_scrape_args} =
+      Keyword.get(opts, :pre_scrape, {__MODULE__, :default_pre_scrape, []})
+
+    apply(pre_scrape_module, pre_scrape_function, pre_scrape_args)
     metrics = TelemetryMetricsPrometheus.Core.scrape(name)
 
     conn
@@ -23,4 +26,6 @@ defmodule TelemetryMetricsPrometheus.Router do
   match _ do
     Conn.send_resp(conn, 404, "Not Found")
   end
+
+  def default_pre_scrape(), do: :ok
 end

--- a/lib/telemetry_metrics_prometheus/router.ex
+++ b/lib/telemetry_metrics_prometheus/router.ex
@@ -11,10 +11,7 @@ defmodule TelemetryMetricsPrometheus.Router do
   get "/metrics" do
     name = opts[:name]
 
-    {pre_scrape_module, pre_scrape_function, pre_scrape_args} =
-      Keyword.get(opts, :pre_scrape, {__MODULE__, :default_pre_scrape, []})
-
-    apply(pre_scrape_module, pre_scrape_function, pre_scrape_args)
+    execute_pre_scrape_handler(opts[:pre_scrape_handler])
     metrics = TelemetryMetricsPrometheus.Core.scrape(name)
 
     conn
@@ -27,5 +24,5 @@ defmodule TelemetryMetricsPrometheus.Router do
     Conn.send_resp(conn, 404, "Not Found")
   end
 
-  def default_pre_scrape(), do: :ok
+  defp execute_pre_scrape_handler({m, f, a}), do: apply(m, f, a)
 end

--- a/lib/telemetry_metrics_prometheus/router.ex
+++ b/lib/telemetry_metrics_prometheus/router.ex
@@ -10,6 +10,8 @@ defmodule TelemetryMetricsPrometheus.Router do
 
   get "/metrics" do
     name = opts[:name]
+    pre_scrape = opts[:pre_scrape]
+    unless is_nil(pre_scrape), do: pre_scrape.()
     metrics = TelemetryMetricsPrometheus.Core.scrape(name)
 
     conn

--- a/lib/telemetry_metrics_prometheus/supervisor.ex
+++ b/lib/telemetry_metrics_prometheus/supervisor.ex
@@ -14,7 +14,12 @@ defmodule TelemetryMetricsPrometheus.Supervisor do
       {TelemetryMetricsPrometheus.Core, args},
       Plug.Cowboy.child_spec(
         scheme: Keyword.get(args, :protocol),
-        plug: {Router, [name: Keyword.get(args, :name)]},
+        plug:
+          {Router,
+           [
+             name: Keyword.get(args, :name),
+             pre_scrape: Keyword.get(args, :pre_scrape)
+           ]},
         options: Keyword.get(args, :options)
       )
     ]

--- a/lib/telemetry_metrics_prometheus/supervisor.ex
+++ b/lib/telemetry_metrics_prometheus/supervisor.ex
@@ -26,5 +26,4 @@ defmodule TelemetryMetricsPrometheus.Supervisor do
 
     Supervisor.init(children, strategy: :rest_for_one)
   end
-
 end

--- a/lib/telemetry_metrics_prometheus/supervisor.ex
+++ b/lib/telemetry_metrics_prometheus/supervisor.ex
@@ -26,4 +26,5 @@ defmodule TelemetryMetricsPrometheus.Supervisor do
 
     Supervisor.init(children, strategy: :rest_for_one)
   end
+
 end

--- a/test/router_test.exs
+++ b/test/router_test.exs
@@ -62,4 +62,48 @@ defmodule TelemetryMetricsPrometheus.RouterTest do
     assert conn.resp_body =~ "http_request_total"
     assert get_resp_header(conn, "content-type") |> hd() =~ "text/plain"
   end
+
+  test "calls the configured pre-scrape" do
+    # Create a test connection
+    conn = conn(:get, "/metrics")
+    test_pid = self()
+
+    _pid =
+      start_supervised!(
+        {TelemetryMetricsPrometheus,
+         [
+           metrics: [
+             Metrics.counter("http.request.total",
+               event_name: [:http, :request, :stop],
+               tags: [:method, :code],
+               description: "The total number of HTTP requests."
+             )
+           ],
+           name: :test,
+           port: 9999,
+           validations: false,
+           monitor_router: true,
+           pre_scrape: fn -> send(test_pid, :invoked) end
+         ]}
+      )
+
+    Process.sleep(10)
+
+    :telemetry.execute([:http, :request, :stop], %{duration: 300_000_000}, %{
+      method: "get",
+      code: 200
+    })
+
+    # Invoke the plug
+    conn =
+      Router.call(conn, Router.init(name: :test, pre_scrape: fn ->  send(test_pid, :invoked) end))
+
+    # Assert the response and status
+    assert conn.state == :sent
+    assert conn.status == 200
+    assert conn.resp_body =~ "http_request_total"
+    assert get_resp_header(conn, "content-type") |> hd() =~ "text/plain"
+
+    assert_receive :invoked
+  end
 end

--- a/test/router_test.exs
+++ b/test/router_test.exs
@@ -54,7 +54,14 @@ defmodule TelemetryMetricsPrometheus.RouterTest do
     })
 
     # Invoke the plug
-    conn = Router.call(conn, Router.init(name: :test))
+    conn =
+      Router.call(
+        conn,
+        Router.init(
+          name: :test,
+          pre_scrape_handler: {TelemetryMetricsPrometheus, :default_pre_scrape_handler, []}
+        )
+      )
 
     # Assert the response and status
     assert conn.state == :sent
@@ -63,7 +70,7 @@ defmodule TelemetryMetricsPrometheus.RouterTest do
     assert get_resp_header(conn, "content-type") |> hd() =~ "text/plain"
   end
 
-  test "calls the configured pre-scrape" do
+  test "calls the configured pre-scrape handler" do
     # Create a test connection
     conn = conn(:get, "/metrics")
     test_pid = self()
@@ -83,7 +90,7 @@ defmodule TelemetryMetricsPrometheus.RouterTest do
            port: 9999,
            validations: false,
            monitor_router: true,
-           pre_scrape: {__MODULE__, :test_scrape, [test_pid]}
+           pre_scrape_handler: {__MODULE__, :test_scrape, [test_pid]}
          ]}
       )
 
@@ -96,7 +103,10 @@ defmodule TelemetryMetricsPrometheus.RouterTest do
 
     # Invoke the plug
     conn =
-      Router.call(conn, Router.init(name: :test, pre_scrape: {__MODULE__, :test_scrape, [test_pid]}))
+      Router.call(
+        conn,
+        Router.init(name: :test, pre_scrape_handler: {__MODULE__, :test_scrape, [test_pid]})
+      )
 
     # Assert the response and status
     assert conn.state == :sent

--- a/test/router_test.exs
+++ b/test/router_test.exs
@@ -83,7 +83,7 @@ defmodule TelemetryMetricsPrometheus.RouterTest do
            port: 9999,
            validations: false,
            monitor_router: true,
-           pre_scrape: fn -> send(test_pid, :invoked) end
+           pre_scrape: {__MODULE__, :test_scrape, [test_pid]}
          ]}
       )
 
@@ -96,7 +96,7 @@ defmodule TelemetryMetricsPrometheus.RouterTest do
 
     # Invoke the plug
     conn =
-      Router.call(conn, Router.init(name: :test, pre_scrape: fn ->  send(test_pid, :invoked) end))
+      Router.call(conn, Router.init(name: :test, pre_scrape: {__MODULE__, :test_scrape, [test_pid]}))
 
     # Assert the response and status
     assert conn.state == :sent
@@ -105,5 +105,9 @@ defmodule TelemetryMetricsPrometheus.RouterTest do
     assert get_resp_header(conn, "content-type") |> hd() =~ "text/plain"
 
     assert_receive :invoked
+  end
+
+  def test_scrape(test_pid) do
+    send(test_pid, :invoked)
   end
 end

--- a/test/telemetry_metrics_prometheus_test.exs
+++ b/test/telemetry_metrics_prometheus_test.exs
@@ -30,6 +30,8 @@ defmodule TelemetryMetricsPrometheusTest do
                     protocol: :http,
                     name: :prometheus_metrics,
                     options: [port: 9568],
+                    pre_scrape_handler:
+                      {TelemetryMetricsPrometheus, :default_pre_scrape_handler, []},
                     metrics: []
                   ]
                 ]}
@@ -50,6 +52,8 @@ defmodule TelemetryMetricsPrometheusTest do
                       certfile: "priv/ssl/cert.pem",
                       dhfile: "priv/ssl/dhparam.pem"
                     ],
+                    pre_scrape_handler:
+                      {TelemetryMetricsPrometheus, :default_pre_scrape_handler, []},
                     metrics: [],
                     protocol: :https
                   ]


### PR DESCRIPTION
Hi,

In order to support `Summary` type metrics with this exporter, we have created a small piece of code that does statistical calculations off those metrics and then exposes them as gauges, so that this exporter can handle them. In order for this to work, a `telemetry_metrics_poller` runs the statistic calculations on the period that has to match the scraping interval.

This has a side-effect of requiring changes to the poller interval every time the scraping interval changes. With this change we could invoke the statistic calculation on the spot, when the `/metrics` endpoint is called, making it always fit the collection period. 

I realize this may be a strange PR to come out of the blue, but I thought it's the easiest way to convey what the proposal is and start a discussion whether that even makes sense. :)