### PR TITLE
Fix the handler name

### DIFF
--- a/lib/telemetry_metrics_prometheus/supervisor.ex
+++ b/lib/telemetry_metrics_prometheus/supervisor.ex
@@ -18,7 +18,7 @@ defmodule TelemetryMetricsPrometheus.Supervisor do
           {Router,
            [
              name: Keyword.get(args, :name),
-             pre_scrape: Keyword.get(args, :pre_scrape)
+             pre_scrape_handler: Keyword.get(args, :pre_scrape_handler)
            ]},
         options: Keyword.get(args, :options)
       )


### PR DESCRIPTION
The handler param name in the `Router` did not match what was set up on the outside, so the scraper was not configurable. :)